### PR TITLE
Add an npm version badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/TheFourFifths/consus.svg?branch=dev)](https://travis-ci.org/TheFourFifths/consus)
 [![codecov](https://codecov.io/gh/TheFourFifths/consus/branch/dev/graph/badge.svg)](https://codecov.io/gh/TheFourFifths/consus)
+[![npm](https://img.shields.io/npm/v/consus.svg)](https://www.npmjs.com/package/consus)
 [![Dependency Status](https://david-dm.org/TheFourFifths/consus.svg)](https://david-dm.org/TheFourFifths/consus)
 [![devDependency Status](https://david-dm.org/TheFourFifths/consus/dev-status.svg)](https://david-dm.org/TheFourFifths/consus?type=dev)
 


### PR DESCRIPTION
### Summary

This adds a version badge for the npm release.

### Checklist

- [x] Did you run `npm test`?
- [x] Did you update/add documentation for new methods or changed functionality?

Finally, is it ready to be reviewed and merged: yes :white_check_mark:

### How to Review

1. Look at the [new badge in the README](https://github.com/TheFourFifths/consus/tree/npm-version-badge#consus).
2. Contain your excitement.
3. Verify that clicking the badge takes you to the npm page for this module.
4. Verify that the latest version is shown by the badge.

### Links

- https://github.com/TheFourFifths/consus/tree/npm-version-badge#consus
- https://www.npmjs.com/package/consus