### PR TITLE
Add modelName to create item response

### DIFF
--- a/docs/REST.md
+++ b/docs/REST.md
@@ -29,7 +29,8 @@ Create an item.
 {
     "status": "success",
     "data": {
-        "address": "iGwEZUvfA"
+        "address": "iGwEZUvfA",
+        "modelName": "Resistor"
     }
 }
 ```

--- a/src/api/item.js
+++ b/src/api/item.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import { addAction } from '../lib/database';
 import ItemStore from '../store/item-store';
+import ModelStore from '../store/model-store';
 
 let app = express();
 
@@ -19,7 +20,10 @@ app.post('/', (req, res) => {
     })
     .then(actionId => {
         let item = ItemStore.getItemByActionId(actionId);
-        res.successJson(item);
+        res.successJson({
+            address: item.address,
+            modelName: ModelStore.getModelByAddress(ItemStore.getItemByAddress(item.address).modelAddress).name
+        });
     })
     .catch(e => {
         res.failureJson(e.message);

--- a/src/api/item.js
+++ b/src/api/item.js
@@ -22,7 +22,7 @@ app.post('/', (req, res) => {
         let item = ItemStore.getItemByActionId(actionId);
         res.successJson({
             address: item.address,
-            modelName: ModelStore.getModelByAddress(ItemStore.getItemByAddress(item.address).modelAddress).name
+            modelName: ModelStore.getModelByAddress(item.modelAddress).name
         });
     })
     .catch(e => {


### PR DESCRIPTION
### Summary

Adds the model name to the item creation response, so that we can display it in an informational toast.

Note that a sister PR (TheFourFifths/consus-client#39) depends on this PR, but this PR does not depend on anything.

### Checklist

- [x] Did you run `npm test`?
- [x] Did you update/add documentation for new methods or changed functionality?

Finally, is it ready to be reviewed and merged: yes :shamrock: 

### How to Review

Consus & Client branch: `toast-new-item-TFF97`

1. Create a new item
1. Witness the `modelName` in the response from the server

### Links

- [TFF-97](https://msoese.atlassian.net/browse/TFF-97)
