### PR TITLE
Hotfix/change model counts

### DIFF
--- a/src/api/item.js
+++ b/src/api/item.js
@@ -34,7 +34,8 @@ app.get('/all', (req, res) => {
 
 app.delete('/', (req, res) => {
     addAction('DELETE_ITEM', {
-        itemAddress: req.query.itemAddress
+        itemAddress: req.query.itemAddress,
+        modelAddress: req.query.modelAddress
     }).then(() => {
         res.successJson({
             items: ItemStore.getItems()

--- a/src/store/model-store.js
+++ b/src/store/model-store.js
@@ -58,6 +58,16 @@ store.registerHandler('CLEAR_ALL_DATA', () => {
     modelsByActionId = new Object(null);
 });
 
+store.registerHandler('NEW_ITEM', data => {
+    let model = store.getModelByAddress(data.modelAddress);
+    model.count += 1;
+});
+
+store.registerHandler('DELETE_ITEM', data => {
+    let model = store.getModelByAddress(data.modelAddress);
+    model.count -= 1;
+});
+
 store.registerHandler('NEW_MODEL', data => {
     let model = {
         address: createAddress(models.length, 'model'),

--- a/test/unit/store/item-store.js
+++ b/test/unit/store/item-store.js
@@ -93,11 +93,14 @@ describe('ItemStore', () => {
               assert.strictEqual(items.length, 2);
           });
     });
+
     it('should delete an item', () =>{
         assert.strictEqual(items.length, 2);
         let deletedItemAddress = items[0].address;
+        let modelAddress = items[0].modelAddress;
         return addAction('DELETE_ITEM', {
-            itemAddress: deletedItemAddress
+            itemAddress: deletedItemAddress,
+            modelAddress: modelAddress
         }).then(items => {
             items = ItemStore.getItems();
             let array = items.filter(t => t.address === deletedItemAddress);

--- a/test/unit/store/model-store.js
+++ b/test/unit/store/model-store.js
@@ -1,4 +1,5 @@
 import ModelStore from '../../../.dist/store/model-store';
+import ItemStore from '../../../.dist/store/item-store';
 import { assert } from 'chai';
 import { addAction } from '../../util/database';
 
@@ -64,6 +65,22 @@ describe('ModelStore', () => {
             assert.strictEqual(model.faultDescription, '');
             assert.strictEqual(model.price, 11.50);
             assert.strictEqual(model.count, 14);
+        });
+    });
+
+    it('should inc/dec the count for item creation/deletion', () =>{
+        assert.strictEqual(model.count, 14);
+        return addAction('NEW_ITEM', {
+            modelAddress: model.address
+        }).then(actionId => {
+            let item = ItemStore.getItemByActionId(actionId);
+            assert.strictEqual(model.count, 15);
+            return addAction('DELETE_ITEM', {
+                itemAddress: item.address,
+                modelAddress: model.address
+            }).then(() => {
+                assert.strictEqual(model.count, 14);
+            });
         });
     });
 


### PR DESCRIPTION
### Summary

When creating and deleting items, the number of models that the item belongs to is now incremented or decremented appropriately.

### Checklist

- [x] Did you run `npm test`?
- [x] Did you update/add documentation for new methods or changed functionality?

Finally, is it ready to be reviewed and merged: 🎄 

### How to Review

1. Run both this branch and the branch of the same name on Consus-Client.
2. Click the view all items button.
3. Click the add an item button
4. Add an item. (keep in mind that just clicking the button without changing the dropdown will create a broken item, so be sure to change the selected item.)
5. Go to the main screen and click on the view all models button.
6. Verify that the number of models of the type of item you created has increased by 1 (check the defaults in the server's model store or just view this before adding an item)
7. Now go to the view all items screen and delete an item.
8. Return to the view all models screen and the model count of the item you deleted, it should have decreased by 1

### Links

SISTER PR https://github.com/TheFourFifths/consus-client/pull/48