### PR TITLE
[TFF-228] Require non-negative quantities for models

### DIFF
--- a/src/store/model-store.js
+++ b/src/store/model-store.js
@@ -137,6 +137,7 @@ store.registerHandler('NEW_MODEL', data => {
     assert.isBoolean(data.allowCheckout, 'The model allowCheckout must be a boolean');
     assert.isNumber(data.price, 'The model price must be a number');
     assert.isNumber(data.count, 'The model count must be a number');
+    assert.isAtLeast(data.count, 0, 'The model count cannot be negative');
     let address = createAddress(models.length, 'model');
     let model = {
         address: address,
@@ -200,7 +201,9 @@ store.registerHandler('EDIT_MODEL', data => {
     assert.isString(data.location, 'The model location must be a string');
     assert.isNumber(data.price, 'The model price must be a number');
     assert.isNumber(data.count, 'The model count must be a number');
+    assert.isAtLeast(data.count, 0, 'The model count cannot be negative');
     assert.isNumber(data.inStock, 'The model stock amount must be a number');
+    assert.isAtLeast(data.inStock, 0, 'The model stock amount cannot be negative');
     updateModel(data.address, data.name, data.description, data.manufacturer, data.vendor, data.location, data.allowCheckout, data.price, data.count, data.changeStock, data.inStock, data.photo);
 });
 

--- a/test/unit/store/model-store.js
+++ b/test/unit/store/model-store.js
@@ -279,4 +279,58 @@ describe('ModelStore', () => {
             assert.strictEqual(e.message, `Address cannot be a serialized model.`);
         });
     });
+
+    it('should require positive values for new model counts', () => {
+        return addAction('NEW_MODEL', {
+            name: 'Transistor',
+            description: 'desc',
+            manufacturer: 'man',
+            vendor: 'vend',
+            location: 'loc',
+            allowCheckout: true,
+            price: 1.00,
+            count: -20
+        }).then(assert.fail).catch(e => {
+            assert.include(e.message, 'The model count cannot be negative');
+        });
+    });
+
+    it('should require positive values for edited model counts', () => {
+        return addAction('EDIT_MODEL', {
+            address: unserializedModel.address,
+            name: 'computer',
+            description: 'WHAT A DESCRIPTION',
+            manufacturer: 'Change it up',
+            vendor: 'vendor',
+            location: 'Neptune',
+            allowCheckout: true,
+            price: 11.50,
+            count: -30,
+            changeStock: true,
+            inStock: 25,
+            photo: 'iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=='
+        }).then(assert.fail).catch(e => {
+            assert.include(e.message, 'The model count cannot be negative');
+        });
+    });
+
+    it('should require positive values for edited model in-stock quantities', () => {
+        return addAction('EDIT_MODEL', {
+            address: unserializedModel.address,
+            name: 'computer',
+            description: 'WHAT A DESCRIPTION',
+            manufacturer: 'Change it up',
+            vendor: 'vendor',
+            location: 'Neptune',
+            allowCheckout: true,
+            price: 11.50,
+            count: 30,
+            changeStock: true,
+            inStock: -25,
+            photo: 'iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=='
+        }).then(assert.fail).catch(e => {
+            assert.include(e.message, 'The model stock amount cannot be negative');
+        });
+    });
+
 });


### PR DESCRIPTION
### Summary

Adds server-side validation for model quantities being non-negative. It appears that this was already fixed on the client as part of the styling work (by adding `min='0'`).

### Checklist

- [x] Have you added unit and functional tests as appropriate?
- [x] Did you update/add documentation for new methods or changed functionality?
- [x] Have you merged the target branch down into this one?

### How to Review

1. Review the diff. It's small.
2. Verify tests / coverage are good.
3. Test locally if you must.

### Links

- [TFF-228](https://msoese.atlassian.net/browse/TFF-228)